### PR TITLE
Remove SplashScreen calls

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -4,7 +4,6 @@ import { StyleSheet, View, YellowBox } from "react-native";
 import { BackButton, NativeRouter } from "react-router-native";
 import { signInAnonymously } from "./helpers/firebase";
 import Firebase from "./helpers/firebase_init";
-import * as SplashScreen from "expo-splash-screen";
 import { Camera } from "expo-camera";
 import { Routes } from "./components/Routes/Routes";
 import { AuthContext } from "./context/AuthContext";
@@ -19,7 +18,6 @@ export default function App() {
   const [hasCameraPermission, setHasCameraPermission] = useState(false);
   signInAnonymously();
   useEffect(() => {
-    SplashScreen.preventAutoHideAsync();
     handleCameraPermission();
     const unlisten = Firebase.auth().onAuthStateChanged((user: any) => {
       user && user.uid ? setUserId(user.uid) : "";
@@ -31,14 +29,9 @@ export default function App() {
 
   useEffect(() => {
     if (userId && hasCameraPermission) {
-      hideSplashScreen();
+      setAppIsReady(true);
     }
   }, [hasCameraPermission, userId]);
-
-  async function hideSplashScreen() {
-    await SplashScreen.hideAsync();
-    setAppIsReady(true);
-  }
 
   async function handleCameraPermission() {
     const { status } = await Camera.requestPermissionsAsync();


### PR DESCRIPTION
1. The app crashes when I try to run it via the Expo emulator on my Android phone.
2. Can't spot any visual difference after removing the expo-splash-screen -calls (what's the benefit of those calls?)