### PR TITLE
Fixes app's inability to recognise landmarks

### DIFF
--- a/frontend/components/CameraPage/Camerapage.tsx
+++ b/frontend/components/CameraPage/Camerapage.tsx
@@ -5,14 +5,16 @@ import { vision } from "../../helpers/api/vision";
 import { uriToBlob } from "../../helpers/uri";
 import { deleteImage, uploadImage } from "../../helpers/firebase";
 import { AuthContext } from "../../context/AuthContext";
+import { CurrentPhotoDataContext } from "../../context/CurrentPhotoDataContext";
 
 const width = Dimensions.get("window").width; //full width
 const height = Dimensions.get("window").height; //full height
 
 export function CameraPage({ handlePhotoData }: any) {
+  const { uri, setUri, landmarks, setLandmarks } = useContext(
+    CurrentPhotoDataContext
+  );
   const [isLoading, setIsLoading] = useState(false);
-  const [uri, setUri] = useState("");
-  const [landmarks, setLandmarks] = useState([]);
   const anonymousUserId = useContext(AuthContext);
 
   useEffect(() => {

--- a/frontend/components/Routes/Routes.tsx
+++ b/frontend/components/Routes/Routes.tsx
@@ -5,22 +5,24 @@ import VotingPage from "../VotingPage";
 import { CurrentPhotoDataContext } from "../../context/CurrentPhotoDataContext";
 
 export function Routes(props: any) {
-  const [photoData, setPhotoData]: any = useState({ uri: "", landmarks: [] });
+  const [uri, setUri] = useState("");
+  const [landmarks, setLandmarks] = useState([]);
   const history = useHistory();
 
   useEffect(() => {
-    if (photoData.uri) {
+    if (uri) {
       history.push("/vote");
     }
-  }, [photoData.uri]);
+  }, [uri]);
 
   function handleImageLocation(photoData: any) {
-    setPhotoData(photoData);
+    setUri(photoData.uri);
+    setLandmarks(photoData.landmarks);
   }
 
   return (
     <CurrentPhotoDataContext.Provider
-      value={{ uri: photoData.uri, landmarks: [] }}
+      value={{ uri: uri, setUri, landmarks: landmarks, setLandmarks }}
     >
       <Switch>
         <Route

--- a/frontend/context/CurrentPhotoDataContext.tsx
+++ b/frontend/context/CurrentPhotoDataContext.tsx
@@ -3,4 +3,6 @@ import { createContext } from "react";
 export const CurrentPhotoDataContext = createContext({
   uri: "",
   landmarks: [],
+  setLandmarks: ([]: any) => {},
+  setUri: (newUri: string) => {},
 });


### PR DESCRIPTION
1. Take a picture of https://fi.wikipedia.org/wiki/Eiffel-torni#/media/Tiedosto:Tour_Eiffel_Wikimedia_Commons_(cropped).jpg
2. Vote "I think it's a landmark"

What happened:
App responded with "Not a landmark" even though Google recognized it as the Eiffel tower

Expected result:
App recognizes the landmark

Background:
CameraPage was setting the landmark results into its own local state. This meant that the VotingPage was unaware of the Google results. Fixed by setting the landmark result in the context.